### PR TITLE
Cover publishState + reduce blocking time

### DIFF
--- a/.github/example_build_hcpbridge.yaml
+++ b/.github/example_build_hcpbridge.yaml
@@ -20,11 +20,6 @@ esphome:
     - emelianov/modbus-esp8266
   platformio_options:
     board_build.f_cpu: 240000000L
-    board_build.flash_mode: qio
-    monitor_speed: 9600
-    monitor_filters: esp32_exception_decoder
-    lib_ldf_mode: deep+
-    # board_build.f_flash: 40000000L
 
 external_components:
   - source:
@@ -142,8 +137,7 @@ wifi:
 
 # Enable logging
 logger:
-  level: DEBUG
-  baud_rate: 9600
+  level: WARN
 
 # Example configuration entry
 ota:

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ esphome:
     - emelianov/modbus-esp8266 # Required for communication with the modbus
   platformio_options:
     board_build.f_cpu: 240000000L
-    board_build.flash_mode: qio
-    monitor_speed: 9600
-    monitor_filters: esp32_exception_decoder
-    lib_ldf_mode: deep+
-    # board_build.f_flash: 40000000L
 
 external_components:
     source: github://14yannick/esphome-hcpbridge
@@ -189,6 +184,7 @@ Check out the [example_hcpbridge.yaml](./example_hcpbridge.yaml) for a complete 
 - HCPBridge from `Tysonpower` on an `Hörmann Promatic 4`
 
 You can find more information on the project here: [Hörmann garage door via MQTT](https://community.home-assistant.io/t/hormann-garage-door-via-mqtt/279938/340)
+Known working hardware are the ESP32 and S3 dual core chip.
 
 # ToDo
 

--- a/components/hcpbridge/binary_sensor/hcpbridge_binarySensor.cpp
+++ b/components/hcpbridge/binary_sensor/hcpbridge_binarySensor.cpp
@@ -4,9 +4,10 @@ namespace esphome{
 namespace hcpbridge{
 
 static const char *const TAG = "hcpbridge.binary_sensor";
+static const char *const TAG2 = "hcpbridge.binary_sensor2";
 
 void HCPBridgeRelaySensor::setup() {
-    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); });
+    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG);
     this->publish_state(false);
 }
 
@@ -20,7 +21,7 @@ void HCPBridgeRelaySensor::dump_config(){
 }
 
 void HCPBridgeIsConnected::setup() {
-    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); });
+    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG2);
     this->publish_state(false);
 }
 
@@ -30,7 +31,7 @@ void HCPBridgeIsConnected::on_event_triggered() {
     }
 }
 void HCPBridgeIsConnected::dump_config(){
-    ESP_LOGCONFIG(TAG, "HCPBridgeIsConnected");
+    ESP_LOGCONFIG(TAG2, "HCPBridgeIsConnected");
 }
 
 }

--- a/components/hcpbridge/cover/hcpbridge_cover.cpp
+++ b/components/hcpbridge/cover/hcpbridge_cover.cpp
@@ -54,7 +54,7 @@ void HCPBridgeCover::control(const cover::CoverCall &call) {
 
 void HCPBridgeCover::setup() {
   ESP_LOGD(TAG, "HCPBridgeCover::setup() - setup method calleds");
-  this->parent_->add_prio_callback([this]() { this->on_event_triggered(); }, TAG);
+  this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG);
 }
 
 void HCPBridgeCover::on_event_triggered() {

--- a/components/hcpbridge/cover/hcpbridge_cover.cpp
+++ b/components/hcpbridge/cover/hcpbridge_cover.cpp
@@ -1,122 +1,120 @@
 #include "hcpbridge_cover.h"
 
-namespace esphome
-{
-  namespace hcpbridge
-  {
-    static const char *const TAG = "hcpbridge.cover";
+namespace esphome {
+namespace hcpbridge {
+static const char *const TAG = "hcpbridge.cover";
 
-    void HCPBridgeCover::on_go_to_open()
-    {
-      ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_open() - opening");
+void HCPBridgeCover::on_go_to_open() {
+  ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_open() - opening");
+  this->parent_->engine->openDoor();
+}
+
+void HCPBridgeCover::on_go_to_close() {
+  ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_close() - closing");
+  this->parent_->engine->closeDoor();
+}
+
+void HCPBridgeCover::on_go_to_half() {
+  ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_half() - half opening");
+  this->parent_->engine->halfPositionDoor();
+}
+
+void HCPBridgeCover::on_go_to_vent() {
+  ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_vent() - venting");
+  this->parent_->engine->ventilationPositionDoor();
+}
+
+cover::CoverTraits HCPBridgeCover::get_traits() {
+  auto traits = cover::CoverTraits();
+  traits.set_is_assumed_state(false);
+  traits.set_supports_position(true);
+  traits.set_supports_tilt(false);
+  traits.set_supports_stop(true);
+  traits.set_supports_toggle(true);
+  return traits;
+}
+
+void HCPBridgeCover::control(const cover::CoverCall &call) {
+  if (call.get_stop()) {
+    this->parent_->engine->stopDoor();
+  }
+  if (call.get_position().has_value()) {
+    if (call.get_position().value() == 1.0f) {
       this->parent_->engine->openDoor();
-    }
-
-    void HCPBridgeCover::on_go_to_close()
-    {
-      ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_close() - closing");
+    } else if (call.get_position().value() == 0.0f) {
       this->parent_->engine->closeDoor();
+    } else {
+      this->parent_->engine->setPosition(call.get_position().value() * 100.0f);
     }
-
-    void HCPBridgeCover::on_go_to_half()
-    {
-      ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_half() - half opening");
-      this->parent_->engine->halfPositionDoor();
-    }
-
-    void HCPBridgeCover::on_go_to_vent()
-    {
-      ESP_LOGD(TAG, "HCPBridgeCover::on_go_to_vent() - venting");
-      this->parent_->engine->ventilationPositionDoor();
-    }
-
-    cover::CoverTraits HCPBridgeCover::get_traits()
-    {
-      auto traits = cover::CoverTraits();
-      traits.set_is_assumed_state(true);
-      traits.set_supports_position(true);
-      traits.set_supports_tilt(false);
-      traits.set_supports_stop(true);
-      traits.set_supports_toggle(true);
-      return traits;
-    }
-
-    void HCPBridgeCover::control(const cover::CoverCall &call)
-    {
-      if (call.get_stop())
-      {
-        this->parent_->engine->stopDoor();
-      }
-      if (call.get_position().has_value())
-      {
-        if (call.get_position().value() == 1.0f)
-        {
-          this->parent_->engine->openDoor();
-        }
-        else if (call.get_position().value() == 0.0f)
-        {
-          this->parent_->engine->closeDoor();
-        }
-        else
-        {
-          this->parent_->engine->setPosition(call.get_position().value() * 100.0f);
-        }
-      }
-      if (call.get_toggle())
-      {
-        this->parent_->engine->impulseDoor();
-      }
-    }
-    void HCPBridgeCover::setup() {
-        ESP_LOGD(TAG, "HCPBridgeCover::setup() - setup method calleds");
-        this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); });
-    }
-    void HCPBridgeCover::on_event_triggered()
-    {
-      if (!this->parent_->engine->state->valid)
-      {
-        if (!this->status_has_warning())
-        {
-          ESP_LOGD(TAG, "HCPBridgeCover::update() - state is invalid");
-          this->status_set_warning();
-        }
-        return;
-      }
-      if (this->status_has_warning())
-      {
-        ESP_LOGD(TAG, "HCPBridgeCover::update() - clearing warning");
-        this->status_clear_warning();
-      }
-
-      switch (this->parent_->engine->state->state)
-      {
-      case HoermannState::OPENING:
-      case HoermannState::MOVE_VENTING:
-      case HoermannState::MOVE_HALF:
-        this->current_operation = cover::COVER_OPERATION_OPENING;
-        break;
-      case HoermannState::CLOSING:
-        this->current_operation = cover::COVER_OPERATION_CLOSING;
-        break;
-      case HoermannState::OPEN:
-      case HoermannState::CLOSED:
-      case HoermannState::STOPPED:
-      case HoermannState::HALFOPEN:
-      case HoermannState::VENT:
-        this->current_operation = cover::COVER_OPERATION_IDLE;
-        break;
-      }
-      this->position = this->parent_->engine->state->currentPosition;
-      if (this->previousPosition_ != this->position || this->previousOperation_ != this->current_operation)
-      {
-        ESP_LOGV(TAG, "HCPBridgeCover::update() - position is %f", this->position);
-        ESP_LOGV(TAG, "HCPBridgeCover::update() - operation is %d", this->current_operation);
-        ESP_LOGD(TAG, "HCPBridgeCover::update() - state changed");
-        this->publish_state(false);
-        this->previousPosition_ = this->position;
-        this->previousOperation_ = this->current_operation;
-      }
-    }
-
+  }
+  if (call.get_toggle()) {
+    this->parent_->engine->impulseDoor();
   }
 }
+
+void HCPBridgeCover::setup() {
+  ESP_LOGD(TAG, "HCPBridgeCover::setup() - setup method calleds");
+  this->parent_->add_prio_callback([this]() { this->on_event_triggered(); }, TAG);
+}
+
+void HCPBridgeCover::on_event_triggered() {
+  if (!this->parent_->engine->state->valid) {
+    if (!this->status_has_warning()) {
+      ESP_LOGD(TAG,
+               "HCPBridgeCover::on_event_triggered() - state is invalid, "
+               "setting warning");
+      this->status_set_warning();
+    }
+    return;
+  }
+
+  if (this->status_has_warning()) {
+    ESP_LOGD(TAG, "HCPBridgeCover::on_event_triggered() - clearing warning");
+    this->status_clear_warning();
+  }
+
+  HoermannState *state = this->parent_->engine->state;
+  float currentPosition = state->currentPosition;
+  HoermannState::State stateValue = state->state;
+
+  // Determine current operation based on state and position
+  switch (stateValue) {
+    case HoermannState::OPENING:
+      this->current_operation = cover::COVER_OPERATION_OPENING;
+      break;
+    case HoermannState::MOVE_VENTING:
+    case HoermannState::MOVE_HALF:
+      if (this->previousPosition_ > currentPosition) {
+        this->current_operation = cover::COVER_OPERATION_OPENING;
+      } else {
+        this->current_operation = cover::COVER_OPERATION_CLOSING;
+      }
+      break;
+    case HoermannState::CLOSING:
+      this->current_operation = cover::COVER_OPERATION_CLOSING;
+      break;
+    default:
+      this->current_operation = cover::COVER_OPERATION_IDLE;
+      break;
+  }
+
+  this->position = currentPosition;
+
+  bool position_changed = this->previousPosition_ != this->position;
+  bool operation_changed = this->previousOperation_ != this->current_operation;
+
+  if (operation_changed) {
+    ESP_LOGV(TAG, "Operation changed: %d", this->current_operation);
+    this->publish_state();  // Full publish on operation change
+    this->previousOperation_ = this->current_operation;
+  } else if (position_changed) {
+    ESP_LOGV(TAG, "Position changed: %f", this->position);
+    this->publish_state(false);  // Partial publish on position change
+  }
+
+  if (position_changed) {
+    this->previousPosition_ = this->position;
+  }
+}
+}  // namespace hcpbridge
+}  // namespace esphome

--- a/components/hcpbridge/hcpbridge.cpp
+++ b/components/hcpbridge/hcpbridge.cpp
@@ -1,28 +1,53 @@
 #include "hcpbridge.h"
 
-namespace esphome
-{
-  namespace hcpbridge
-  {
+namespace esphome {
+namespace hcpbridge {
 
-    void HCPBridge::setup()
-    {
-      int8_t rx = this->rx_pin_ == nullptr ? PIN_RXD : this->rx_pin_->get_pin();
-      int8_t tx = this->tx_pin_ == nullptr ? PIN_TXD : this->tx_pin_->get_pin();
-      int8_t rts = this->rts_pin_ == nullptr ? -1 : this->rts_pin_->get_pin();
+static const char *TAG = "hcpbridge";
+void HCPBridge::setup() {
+  int8_t rx = this->rx_pin_ == nullptr ? PIN_RXD : this->rx_pin_->get_pin();
+  int8_t tx = this->tx_pin_ == nullptr ? PIN_TXD : this->tx_pin_->get_pin();
+  int8_t rts = this->rts_pin_ == nullptr ? -1 : this->rts_pin_->get_pin();
 
-      this->engine = &HoermannGarageEngine::getInstance();
-      this->engine->setup(rx, tx, rts);
+  this->engine = &HoermannGarageEngine::getInstance();
+  this->engine->setup(rx, tx, rts);
+}
+void HCPBridge::add_on_state_callback(std::function<void()> &&callback) {
+  auto wrapped_callback = [callback]() {
+    auto start = millis();
+    callback();
+    auto end = millis();
+    ESP_LOGD(TAG, "Callback executed in %u ms", end - start);
+  };
+  this->state_callback_.add(std::move(wrapped_callback));
+}
+
+void HCPBridge::add_prio_callback(std::function<void()> &&callback, const char *tag) {
+  auto wrapped_callback = [callback, tag]() {
+    auto start = millis();
+    callback();
+    auto end = millis();
+    ESP_LOGD(TAG, "Callback executed in %u ms [Tag: %s]", end - start, tag);
+  };
+  this->prio_callback_.add(std::move(wrapped_callback));
+}
+
+void HCPBridge::update() {
+  static bool is_prio_callback_next = true;
+
+  if (this->engine->state->changed) {
+    if (is_prio_callback_next) {
+      this->prio_callback_.call();
+    } else {
+      this->state_callback_.call(); 
     }
-    void HCPBridge::add_on_state_callback(std::function<void()> &&callback){
-      this->state_callback_.add(std::move(callback)); 
-    }
 
-    void HCPBridge::update(){
-      if (this->engine->state->changed) {
-        this->engine->state->clearChanged();
-        this->state_callback_.call();
-      }
+    is_prio_callback_next = !is_prio_callback_next;
+
+    if (is_prio_callback_next) { 
+      this->engine->state->clearChanged();
     }
   }
 }
+}  // namespace hcpbridge
+}  // namespace esphome

--- a/components/hcpbridge/hcpbridge.cpp
+++ b/components/hcpbridge/hcpbridge.cpp
@@ -12,41 +12,20 @@ void HCPBridge::setup() {
   this->engine = &HoermannGarageEngine::getInstance();
   this->engine->setup(rx, tx, rts);
 }
-void HCPBridge::add_on_state_callback(std::function<void()> &&callback) {
-  auto wrapped_callback = [callback]() {
-    auto start = millis();
-    callback();
-    auto end = millis();
-    ESP_LOGD(TAG, "Callback executed in %u ms", end - start);
-  };
-  this->state_callback_.add(std::move(wrapped_callback));
-}
-
-void HCPBridge::add_prio_callback(std::function<void()> &&callback, const char *tag) {
+void HCPBridge::add_on_state_callback(std::function<void()> &&callback, const char *tag) {
   auto wrapped_callback = [callback, tag]() {
     auto start = millis();
     callback();
     auto end = millis();
     ESP_LOGD(TAG, "Callback executed in %u ms [Tag: %s]", end - start, tag);
   };
-  this->prio_callback_.add(std::move(wrapped_callback));
+  this->state_callback_.add(std::move(wrapped_callback));
 }
 
 void HCPBridge::update() {
-  static bool is_prio_callback_next = true;
-
   if (this->engine->state->changed) {
-    if (is_prio_callback_next) {
-      this->prio_callback_.call();
-    } else {
-      this->state_callback_.call(); 
-    }
-
-    is_prio_callback_next = !is_prio_callback_next;
-
-    if (is_prio_callback_next) { 
-      this->engine->state->clearChanged();
-    }
+    this->engine->state->clearChanged();
+    this->state_callback_.call();
   }
 }
 }  // namespace hcpbridge

--- a/components/hcpbridge/hcpbridge.h
+++ b/components/hcpbridge/hcpbridge.h
@@ -18,7 +18,7 @@ class HCPBridge : public PollingComponent {
   void set_rx_pin(InternalGPIOPin *rx_pin) { this->rx_pin_ = rx_pin; }
   void set_rts_pin(InternalGPIOPin *rts_pin) { this->rts_pin_ = rts_pin; }
   HoermannGarageEngine *engine;
-  void add_on_state_callback(std::function<void()> &&callback);
+  void add_on_state_callback(std::function<void()> &&callback, const char *tag);
   void add_prio_callback(std::function<void()> &&callback, const char *tag);
 
  protected:
@@ -26,7 +26,6 @@ class HCPBridge : public PollingComponent {
   InternalGPIOPin *rx_pin_;
   InternalGPIOPin *rts_pin_;
   CallbackManager<void()> state_callback_;
-  CallbackManager<void()> prio_callback_;
 };
 }  // namespace hcpbridge
 }  // namespace esphome

--- a/components/hcpbridge/hcpbridge.h
+++ b/components/hcpbridge/hcpbridge.h
@@ -5,30 +5,28 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-
 #include "hoermann.h"
 
-namespace esphome
-{
-  namespace hcpbridge
-  {
+namespace esphome {
+namespace hcpbridge {
 
-    class HCPBridge : public PollingComponent
-    {
-      public:
-        void setup() override;
-        void update() override;  
-        void set_tx_pin(InternalGPIOPin *tx_pin) { this->tx_pin_ = tx_pin; }
-        void set_rx_pin(InternalGPIOPin *rx_pin) { this->rx_pin_ = rx_pin; }
-        void set_rts_pin(InternalGPIOPin *rts_pin) { this->rts_pin_ = rts_pin; }
-        HoermannGarageEngine* engine;
-        void add_on_state_callback(std::function<void()> &&callback);
+class HCPBridge : public PollingComponent {
+ public:
+  void setup() override;
+  void update() override;
+  void set_tx_pin(InternalGPIOPin *tx_pin) { this->tx_pin_ = tx_pin; }
+  void set_rx_pin(InternalGPIOPin *rx_pin) { this->rx_pin_ = rx_pin; }
+  void set_rts_pin(InternalGPIOPin *rts_pin) { this->rts_pin_ = rts_pin; }
+  HoermannGarageEngine *engine;
+  void add_on_state_callback(std::function<void()> &&callback);
+  void add_prio_callback(std::function<void()> &&callback, const char *tag);
 
-      protected:
-        InternalGPIOPin *tx_pin_;
-        InternalGPIOPin *rx_pin_;
-        InternalGPIOPin *rts_pin_;
-        CallbackManager<void()> state_callback_;
-    };
-  }
-}
+ protected:
+  InternalGPIOPin *tx_pin_;
+  InternalGPIOPin *rx_pin_;
+  InternalGPIOPin *rts_pin_;
+  CallbackManager<void()> state_callback_;
+  CallbackManager<void()> prio_callback_;
+};
+}  // namespace hcpbridge
+}  // namespace esphome

--- a/components/hcpbridge/light/hcpbridge_light.cpp
+++ b/components/hcpbridge/light/hcpbridge_light.cpp
@@ -14,7 +14,7 @@ light::LightTraits HCPBridgeLight::get_traits() {
 
 void HCPBridgeLight::setup() {
     ESP_LOGD(TAG, "HCPBridgeLight::setup() - setup method calleds");
-    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); });
+    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG);
 }
 
 void HCPBridgeLight::write_state(light::LightState *state) {

--- a/components/hcpbridge/sensor/hcpbridge_sensor.cpp
+++ b/components/hcpbridge/sensor/hcpbridge_sensor.cpp
@@ -7,8 +7,7 @@ namespace hcpbridge {
 static const char *TAG = "hcpbridge.sensor";
 
 void HCPBridgeSensor::setup() {
-  this->parent_->add_on_state_callback(
-      [this]() { this->on_event_triggered(); });
+  this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG);
   this->update_state(0.0f);
 }
 

--- a/components/hcpbridge/switch/hcpbridge_switch.cpp
+++ b/components/hcpbridge/switch/hcpbridge_switch.cpp
@@ -4,11 +4,12 @@ namespace esphome {
 namespace hcpbridge {
 
 static const char *const TAG = "hcpbridge.switch";
+static const char *const TAG2 = "hcpbridge.switch2";
 
 // Implementation for HCPBridgeSwitchVent
 
 void HCPBridgeSwitchVent::setup() {
-    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); });
+    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG);
 }
 
 void HCPBridgeSwitchVent::on_event_triggered() {
@@ -57,7 +58,7 @@ void HCPBridgeSwitchVent::write_state(bool state) {
 // Implementation for HCPBridgeSwitchHalf
 
 void HCPBridgeSwitchHalf::setup() {
-    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); });
+    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG2);
 }
 
 void HCPBridgeSwitchHalf::on_event_triggered() {

--- a/components/hcpbridge/text_sensor/hcpbridge_textSensor.cpp
+++ b/components/hcpbridge/text_sensor/hcpbridge_textSensor.cpp
@@ -7,9 +7,7 @@ static const char *const TAG = "hcpbridge.text_sensor";
 
 void HCPBridgeTextSensor::setup() {
   if (this->parent_ != nullptr) {
-    this->parent_->add_on_state_callback([this]() {
-        this->on_event_triggered(); 
-    });
+    this->parent_->add_on_state_callback([this]() { this->on_event_triggered(); }, TAG);
   }
 }
 

--- a/example_hcpbridge.yaml
+++ b/example_hcpbridge.yaml
@@ -20,11 +20,6 @@ esphome:
     - emelianov/modbus-esp8266
   platformio_options:
     board_build.f_cpu: 240000000L
-    board_build.flash_mode: qio
-    monitor_speed: 9600
-    monitor_filters: esp32_exception_decoder
-    lib_ldf_mode: deep+
-    # board_build.f_flash: 40000000L
 
 external_components:
     source: github://14yannick/esphome-hcpbridge
@@ -137,20 +132,13 @@ api:
       then:
         - cover.toggle: garagedoor_cover
 
-web_server:
-  port: 80
-  auth:
-    username: !secret web_username
-    password: !secret web_password
-
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
 # Enable logging
 logger:
-  level: DEBUG
-  baud_rate: 9600
+  level: WARN
 
 # Example configuration entry
 ota:


### PR DESCRIPTION
Set   traits.set_is_assumed_state(false) of the cover to false and publish it on state change.
Remove uart Log and set default Log level to Warn to optimize blocking time.
Add somme debug message to be able to track time consumption by component.