### PR TITLE
Fix COVER_SCHEMA deprecation

### DIFF
--- a/components/hcpbridge/cover/__init__.py
+++ b/components/hcpbridge/cover/__init__.py
@@ -12,8 +12,7 @@ DEPENDENCIES = ['hcpbridge']
 HCPBridgeCover = hcpbridge_ns.class_("HCPBridgeCover", cover.Cover, cg.Component)
 
 CONFIG_SCHEMA = cv.All(
-  cover.cover_schema(HCPBridgeCover)
-  .extend({
+  cover.cover_schema(HCPBridgeCover).extend({
     cv.GenerateID(): cv.declare_id(HCPBridgeCover),
     cv.GenerateID(CONF_HCPBridge_ID): cv.use_id(HCPBridge),
   }),

--- a/components/hcpbridge/cover/__init__.py
+++ b/components/hcpbridge/cover/__init__.py
@@ -12,7 +12,8 @@ DEPENDENCIES = ['hcpbridge']
 HCPBridgeCover = hcpbridge_ns.class_("HCPBridgeCover", cover.Cover, cg.Component)
 
 CONFIG_SCHEMA = cv.All(
-  cover.COVER_SCHEMA.extend({
+  cover.cover_schema(HCPBridgeCover)
+  .extend({
     cv.GenerateID(): cv.declare_id(HCPBridgeCover),
     cv.GenerateID(CONF_HCPBridge_ID): cv.use_id(HCPBridge),
   }),


### PR DESCRIPTION
When building this codebase, I get
```
WARNING Using `cover.COVER_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. Please use `cover.cover_schema(...)` instead. If you are seeing this, report an issue to the external_component author and ask them to update it. https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. Component using this schema: hcpbridge
```
Code seems to validate by ESPhome, I will do some more testing on whether this doesn't introduce any weird side effects.