### PR TITLE
Add new `slave_id` YAML option to set custom Modbus address

### DIFF
--- a/components/hcpbridge/__init__.py
+++ b/components/hcpbridge/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
 )
 
 CONF_RTS_PIN = "rts_pin"
+CONF_SLAVE_ID = "slave_id"
 
 hcpbridge_ns = cg.esphome_ns.namespace("hcpbridge")
 HCPBridge = hcpbridge_ns.class_("HCPBridge", cg.PollingComponent)
@@ -20,6 +21,7 @@ CONFIG_SCHEMA = cv.All(
         cv.Optional(CONF_RX_PIN): pins.gpio_input_pin_schema,
         cv.Optional(CONF_TX_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RTS_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_SLAVE_ID, default=2): cv.int_range(1, 247),
     }).extend(cv.polling_component_schema("500ms")),
 )
 
@@ -36,3 +38,5 @@ async def to_code(config):
   if CONF_RTS_PIN in config:
     rts_pin = await cg.gpio_pin_expression(config[CONF_RTS_PIN])
     cg.add(var.set_rts_pin(rts_pin))
+  if CONF_SLAVE_ID in config:
+    cg.add(var.set_slave_id(config[CONF_SLAVE_ID]))

--- a/components/hcpbridge/__init__.py
+++ b/components/hcpbridge/__init__.py
@@ -21,7 +21,7 @@ CONFIG_SCHEMA = cv.All(
         cv.Optional(CONF_RX_PIN): pins.gpio_input_pin_schema,
         cv.Optional(CONF_TX_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RTS_PIN): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_SLAVE_ID, default=2): cv.int_range(1, 247),
+        cv.Optional(CONF_SLAVE_ID, default=2): cv.int_range(1, 243),
     }).extend(cv.polling_component_schema("500ms")),
 )
 

--- a/components/hcpbridge/hcpbridge.cpp
+++ b/components/hcpbridge/hcpbridge.cpp
@@ -8,9 +8,10 @@ void HCPBridge::setup() {
   int8_t rx = this->rx_pin_ == nullptr ? PIN_RXD : this->rx_pin_->get_pin();
   int8_t tx = this->tx_pin_ == nullptr ? PIN_TXD : this->tx_pin_->get_pin();
   int8_t rts = this->rts_pin_ == nullptr ? -1 : this->rts_pin_->get_pin();
+  int slave_id = this->slave_id_;
 
   this->engine = &HoermannGarageEngine::getInstance();
-  this->engine->setup(rx, tx, rts);
+  this->engine->setup(rx, tx, rts, slave_id);
 }
 void HCPBridge::add_on_state_callback(std::function<void()> &&callback, const char *tag) {
   auto wrapped_callback = [callback, tag]() {

--- a/components/hcpbridge/hcpbridge.h
+++ b/components/hcpbridge/hcpbridge.h
@@ -17,6 +17,7 @@ class HCPBridge : public PollingComponent {
   void set_tx_pin(InternalGPIOPin *tx_pin) { this->tx_pin_ = tx_pin; }
   void set_rx_pin(InternalGPIOPin *rx_pin) { this->rx_pin_ = rx_pin; }
   void set_rts_pin(InternalGPIOPin *rts_pin) { this->rts_pin_ = rts_pin; }
+  void set_slave_id(int slave_id) { this->slave_id_ = slave_id; }
   HoermannGarageEngine *engine;
   void add_on_state_callback(std::function<void()> &&callback, const char *tag);
   void add_prio_callback(std::function<void()> &&callback, const char *tag);
@@ -25,6 +26,7 @@ class HCPBridge : public PollingComponent {
   InternalGPIOPin *tx_pin_;
   InternalGPIOPin *rx_pin_;
   InternalGPIOPin *rts_pin_;
+  int slave_id_;
   CallbackManager<void()> state_callback_;
 };
 }  // namespace hcpbridge

--- a/components/hcpbridge/hoermann.cpp
+++ b/components/hcpbridge/hoermann.cpp
@@ -36,7 +36,7 @@ HoermannGarageEngine &HoermannGarageEngine::getInstance()
   return instance;
 }
 
-void HoermannGarageEngine::setup(int8_t rx, int8_t tx, int8_t rts)
+void HoermannGarageEngine::setup(int8_t rx, int8_t tx, int8_t rts, int slave_id)
 {
   RS485.begin(57600, SERIAL_8E1, rx, tx);
   if (rts == -1) {
@@ -44,7 +44,7 @@ void HoermannGarageEngine::setup(int8_t rx, int8_t tx, int8_t rts)
   } else {
     mb.begin(&RS485, rts, true);
   }
-  mb.slave(SLAVE_ID);
+  mb.slave(slave_id);
 
   xTaskCreatePinnedToCore(
       modbusServeTask, /* Function to implement the task */

--- a/components/hcpbridge/hoermann.h
+++ b/components/hcpbridge/hoermann.h
@@ -106,7 +106,7 @@ public:
 
     static HoermannGarageEngine& getInstance();
 
-    void setup(int8_t rx, int8_t tx, int8_t rts);
+    void setup(int8_t rx, int8_t tx, int8_t rts, int slave_id);
     void handleModbus();
     Modbus::ResultCode onRequest(Modbus::FunctionCode fc, const Modbus::RequestData data);
     void setCommandValuesToRead();


### PR DESCRIPTION
Does basically what's written on the tin. 🥫

I tried to avoid that `nullptr` comparison and used `default=2` instead.
This _should work_, but we need some additional testing to be sure.

Relevant for #15